### PR TITLE
fix: ci publish CY-4744

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@2.0.1
+  codacy: codacy/base@5.2.3
 
 workflows:
   version: 2
@@ -31,10 +31,9 @@ workflows:
           requires:
             - codacy/checkout_and_version
       - codacy/sbt:
-          name: publish_sonatype
+          name: publish
           context: CodacyAWS
-          cmd: |
-            sbt "retrieveGPGKeys;+publishSigned;sonatypeReleaseAll"
+          cmd: sbt retrieveGPGKeys +publishSigned sonatypeBundleRelease
           requires:
             - compile_test
           filters:
@@ -45,4 +44,4 @@ workflows:
           name: tag_version
           context: CodacyAWS
           requires:
-            - publish_sonatype
+            - publish

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.6
+sbt.version=1.4.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 resolvers += Resolver.jcenterRepo
-addSbtPlugin("com.codacy" % "codacy-sbt-plugin" % "17.1.5")
+addSbtPlugin("com.codacy" % "codacy-sbt-plugin" % "20.1.0")
 addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.9")


### PR DESCRIPTION
This will enable this lib to start publishing again, making a new version available that has the latest codacy-plugins-api (with Terraform in the languages)

Bumping this in the metrics tools that read "Terraform" as a language from the .codacyrc file will make the following stop happening 
![image](https://user-images.githubusercontent.com/36695843/129237194-f0658d71-e687-488f-98f4-9ee3e44206f3.png)
